### PR TITLE
fix: Correct SyntaxError in query_tensor_directory signature

### DIFF
--- a/tensordirectory/mcp_interface.py
+++ b/tensordirectory/mcp_interface.py
@@ -118,7 +118,7 @@ async def upload_model_resource(name: str, description: str, ctx: Context, model
         return {"error": f"An unexpected error occurred while uploading model '{name}': {str(e)}"}
 
 @mcp_server.tool()
-async def query_tensor_directory(prompt: str, params: dict | None = None, ctx: Context) -> str:
+async def query_tensor_directory(prompt: str, ctx: Context, params: dict | None = None) -> str:
     """
     Processes a user's prompt to query the tensor directory.
     The AI agent will interpret the prompt, retrieve data, or use an inference model.


### PR DESCRIPTION
The `ctx: Context` parameter in the `query_tensor_directory` function in `tensordirectory/mcp_interface.py` was incorrectly placed after the `params` parameter, which has a default value.

This commit moves `ctx` before `params` to resolve the Python SyntaxError ("non-default argument follows default argument"). This addresses a similar issue missed in the previous fix for `upload_model_resource`.