### PR TITLE
fix: Address multiple unit test failures across the suite

### DIFF
--- a/tensordirectory/main.py
+++ b/tensordirectory/main.py
@@ -16,7 +16,7 @@ import sys
 # Check for critical external dependencies first
 try:
     import google.generativeai
-    import mcp.server.fastmcp 
+    import mcp.server.fastmcp
     # You can also import specific items if preferred, e.g.:
     # from google.generativeai import GenerativeModel
     # from mcp.server.fastmcp import FastMCP
@@ -50,7 +50,7 @@ except ImportError as e:
 # Configure basic logging for the rest of the application
 # This will be used if the above checks pass.
 logging.basicConfig(
-    stream=sys.stdout, 
+    stream=sys.stdout,
     level=logging.INFO,
     format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
 )

--- a/tensordirectory/storage.py
+++ b/tensordirectory/storage.py
@@ -42,17 +42,17 @@ def _initialize_hdf5():
 
         if '/indices/tensor_name_to_uuid' not in hf:
             # Create an empty, resizable dataset to store (name, uuid) pairs
-            hf.create_dataset('/indices/tensor_name_to_uuid', 
-                              shape=(0, 2), 
-                              maxshape=(None, 2), 
+            hf.create_dataset('/indices/tensor_name_to_uuid',
+                              shape=(0, 2),
+                              maxshape=(None, 2),
                               dtype=string_dt,
                               chunks=True)
-            
+
         if '/indices/model_name_to_uuid' not in hf:
             # Create an empty, resizable dataset to store (name, uuid) pairs
-            hf.create_dataset('/indices/model_name_to_uuid', 
-                              shape=(0, 2), 
-                              maxshape=(None, 2), 
+            hf.create_dataset('/indices/model_name_to_uuid',
+                              shape=(0, 2),
+                              maxshape=(None, 2),
                               dtype=string_dt,
                               chunks=True)
 
@@ -90,24 +90,24 @@ def save_tensor(name: str, description: str, tensor_data: np.ndarray) -> str:
         # Update tensor_name_to_uuid mapping
         mapping_path = '/indices/tensor_name_to_uuid'
         mappings = hf[mapping_path]
-        
+
         # Convert to list for easier manipulation
         mappings_list = list(mappings[:])
-        
+
         name_exists = False
         for i, (existing_name, _) in enumerate(mappings_list):
             if existing_name == name:
                 mappings_list[i] = (name, tensor_uuid)
                 name_exists = True
                 break
-        
+
         if not name_exists:
             mappings_list.append((name, tensor_uuid))
-        
+
         # Resize and write back
         if len(mappings_list) > mappings.shape[0] :
              mappings.resize((len(mappings_list), 2))
-        
+
         # Ensure data is in NumPy array format before writing
         # This step can be tricky with variable length strings if not handled correctly.
         # h5py expects a NumPy array (or similar) for dataset writes.
@@ -146,7 +146,7 @@ def get_tensor_by_uuid(uuid_str: str) -> tuple[np.ndarray | None, dict | None]:
                 tensor_data = dset[:]
                 metadata = dict(dset.attrs)
                 # Add the UUID to the metadata dict for convenience for the caller
-                metadata['uuid'] = uuid_str 
+                metadata['uuid'] = uuid_str
                 return tensor_data, metadata
             else:
                 return None, None
@@ -171,31 +171,37 @@ def get_tensor_by_name(name: str) -> tuple[np.ndarray | None, dict | None]:
         A tuple (tensor_data, metadata_dict) or (None, None) if not found.
     """
     _initialize_hdf5()
+    found_uuid = None  # Initialize here
+
     try:
         with h5py.File(HDF5_FILE_NAME, 'r') as hf:
             mapping_path = '/indices/tensor_name_to_uuid'
             if mapping_path not in hf:
-                return None, None # Index itself doesn't exist
-
-            mappings = hf[mapping_path][:]
-            
-            found_uuid = None
-            # Iterate by index to handle potential byte arrays from h5py
-            for i in range(mappings.shape[0]): 
-                stored_name_raw = mappings[i, 0]
-                stored_uuid_raw = mappings[i, 1]
-
-                # Decode if bytes, otherwise assume str
-                current_stored_name = stored_name_raw.decode('utf-8') if isinstance(stored_name_raw, bytes) else str(stored_name_raw)
-                
-                if current_stored_name == name: # name is input Python str
-                    found_uuid = stored_uuid_raw.decode('utf-8') if isinstance(stored_uuid_raw, bytes) else str(stored_uuid_raw)
-                    break
-            
-            if found_uuid:
-                return get_tensor_by_uuid(found_uuid)
+                # Index itself doesn't exist, found_uuid remains None
+                pass
             else:
-                return None, None
+                mappings = hf[mapping_path][:]
+                # Iterate by index to handle potential byte arrays from h5py
+                for i in range(mappings.shape[0]):
+                    stored_name_raw = mappings[i, 0]
+                    stored_uuid_raw = mappings[i, 1]
+
+                    # Decode if bytes, otherwise assume str
+                    current_stored_name = stored_name_raw.decode('utf-8') if isinstance(stored_name_raw, bytes) else str(stored_name_raw)
+
+                    if current_stored_name == name: # name is input Python str
+                        found_uuid = stored_uuid_raw.decode('utf-8') if isinstance(stored_uuid_raw, bytes) else str(stored_uuid_raw)
+                        break
+
+        # ---- End of 'with' block for reading the index ----
+        # Now hf (for index read) is closed. Proceed based on found_uuid.
+
+        if found_uuid:
+            # This call will open the file again, but the previous handle is closed.
+            return get_tensor_by_uuid(found_uuid)
+        else:
+            return None, None
+
     except FileNotFoundError:
         return None, None
     except Exception as e:
@@ -225,13 +231,13 @@ def find_tensors(metadata_query: dict) -> list[tuple[np.ndarray, dict]]:
             for uuid_str in tensors_group:
                 dset = tensors_group[uuid_str]
                 metadata = dict(dset.attrs)
-                
+
                 match = True
                 for query_key, query_value in metadata_query.items():
                     if metadata.get(query_key) != query_value:
                         match = False
                         break
-                
+
                 if match:
                     tensor_data = dset[:]
                     matches.append((tensor_data, metadata))
@@ -294,20 +300,20 @@ def save_model(name: str, description: str, model_weights: np.ndarray | None = N
                 mappings_list[i] = (name, model_uuid)
                 name_exists = True
                 break
-        
+
         if not name_exists:
             mappings_list.append((name, model_uuid))
-        
+
         if len(mappings_list) > mappings.shape[0]:
             mappings.resize((len(mappings_list), 2))
-        
+
         if mappings_list:
             string_dt = h5py.string_dtype(encoding='utf-8')
             new_mappings_arr = np.array(mappings_list, dtype=string_dt)
             hf[mapping_path][:] = new_mappings_arr
         elif mappings.shape[0] > 0:
             hf[mapping_path].resize((0,2))
-            
+
     return model_uuid
 
 def get_model_by_uuid(uuid_str: str) -> dict | None:
@@ -330,11 +336,11 @@ def get_model_by_uuid(uuid_str: str) -> dict | None:
 
             model_group = hf[model_group_path]
             metadata = dict(model_group.attrs)
-            
+
             model_weights = None
             if 'weights' in model_group:
                 model_weights = model_group['weights'][:]
-            
+
             model_code = None
             if 'code' in model_group:
                 # Data is stored as bytes, needs decoding if it's not auto-handled by string_dt read
@@ -343,7 +349,7 @@ def get_model_by_uuid(uuid_str: str) -> dict | None:
                      model_code = code_data.decode('utf-8')
                 else: # Should be a string if stored with h5py.string_dtype
                     model_code = code_data
-            
+
             # Add the UUID to the metadata dict for convenience
             metadata['uuid'] = uuid_str
 
@@ -371,31 +377,37 @@ def get_model_by_name(name: str) -> dict | None:
         or None if not found.
     """
     _initialize_hdf5()
+    found_uuid = None  # Initialize here
+
     try:
         with h5py.File(HDF5_FILE_NAME, 'r') as hf:
             mapping_path = '/indices/model_name_to_uuid'
             if mapping_path not in hf:
-                return None # Index itself doesn't exist
-
-            mappings = hf[mapping_path][:]
-            
-            found_uuid = None
-            # Iterate by index to handle potential byte arrays from h5py
-            for i in range(mappings.shape[0]):
-                stored_name_raw = mappings[i, 0]
-                stored_uuid_raw = mappings[i, 1]
-
-                # Decode if bytes, otherwise assume str
-                current_stored_name = stored_name_raw.decode('utf-8') if isinstance(stored_name_raw, bytes) else str(stored_name_raw)
-                
-                if current_stored_name == name: # name is input Python str
-                    found_uuid = stored_uuid_raw.decode('utf-8') if isinstance(stored_uuid_raw, bytes) else str(stored_uuid_raw)
-                    break
-            
-            if found_uuid:
-                return get_model_by_uuid(found_uuid)
+                # Index itself doesn't exist, found_uuid remains None
+                pass
             else:
-                return None
+                mappings = hf[mapping_path][:]
+                # Iterate by index to handle potential byte arrays from h5py
+                for i in range(mappings.shape[0]):
+                    stored_name_raw = mappings[i, 0]
+                    stored_uuid_raw = mappings[i, 1]
+
+                    # Decode if bytes, otherwise assume str
+                    current_stored_name = stored_name_raw.decode('utf-8') if isinstance(stored_name_raw, bytes) else str(stored_name_raw)
+
+                    if current_stored_name == name: # name is input Python str
+                        found_uuid = stored_uuid_raw.decode('utf-8') if isinstance(stored_uuid_raw, bytes) else str(stored_uuid_raw)
+                        break
+
+        # ---- End of 'with' block for reading the index ----
+        # Now hf (for index read) is closed. Proceed based on found_uuid.
+
+        if found_uuid:
+            # This call will open the file again, but the previous handle is closed.
+            return get_model_by_uuid(found_uuid)
+        else:
+            return None
+
     except FileNotFoundError:
         return None
     except Exception as e:


### PR DESCRIPTION
This commit includes several fixes to resolve unit test failures identified in `test_storage.py`, `test_agent.py`, and `test_mcp_interface.py`.

Key changes:

1.  **`storage.py`**:
    - Refined HDF5 file handling in `get_tensor_by_name` and `get_model_by_name`. Ensured the file handle used for index lookup is closed before calling internal `get_..._by_uuid` functions. This resolves "file already open" errors in `test_storage.py`.

2.  **`tests/test_agent.py`**:
    - Corrected mocking for `ensure_gemini_configured` tests (`test_01_...`, `test_02_...`) by patching `agent.GEMINI_API_KEY` directly, rather than `os.getenv` after module load.
    - Fixed `IndexError` in `test_10_handle_query_run_inference_success` by correctly accessing keyword arguments from `mock_save_tensor.call_args.kwargs`.

3.  **`tests/test_mcp_interface.py`**:
    - Resolved `NameError` in `test_07c_...storage_failure` by updating the Pydantic model name from `ModelUploadRequest` to `ModelUploadArgs`.
    - Fixed "unexpected success" errors in `test_03b_...value_error_on_conversion` and `test_07b_...value_error_on_conversion`. These tests now correctly simulate `np.array()` raising a `ValueError` by mocking `np.array` itself.
    - Corrected the mock assertion for `invoke_agent_query` in `test_08_query_tensor_directory_tool` to use keyword arguments, matching the actual call signature.