### PR TITLE
fix: Correct overwrite logic in storage.py name-to-UUID indexing

### DIFF
--- a/tensordirectory/storage.py
+++ b/tensordirectory/storage.py
@@ -92,11 +92,17 @@ def save_tensor(name: str, description: str, tensor_data: np.ndarray) -> str:
         mappings = hf[mapping_path]
 
         # Convert to list for easier manipulation
-        mappings_list = list(mappings[:])
+        mappings_list = list(mappings[:]) # Contains (name_raw, uuid_raw) tuples
 
         name_exists = False
-        for i, (existing_name, _) in enumerate(mappings_list):
-            if existing_name == name:
+        for i in range(len(mappings_list)):
+            existing_name_raw, old_uuid_raw = mappings_list[i] # Get raw values
+
+            # Decode existing_name_raw if it's bytes
+            current_existing_name = existing_name_raw.decode('utf-8') if isinstance(existing_name_raw, bytes) else str(existing_name_raw)
+
+            if current_existing_name == name: # Compare decoded str with input str
+                # Update with input 'name' (already str) and new 'tensor_uuid' (already str)
                 mappings_list[i] = (name, tensor_uuid)
                 name_exists = True
                 break
@@ -292,11 +298,17 @@ def save_model(name: str, description: str, model_weights: np.ndarray | None = N
         # Update model_name_to_uuid mapping
         mapping_path = '/indices/model_name_to_uuid'
         mappings = hf[mapping_path]
-        mappings_list = list(mappings[:])
+        mappings_list = list(mappings[:]) # Contains (name_raw, uuid_raw) tuples
 
         name_exists = False
-        for i, (existing_name, _) in enumerate(mappings_list):
-            if existing_name == name:
+        for i in range(len(mappings_list)):
+            existing_name_raw, old_uuid_raw = mappings_list[i] # Get raw values
+
+            # Decode existing_name_raw if it's bytes
+            current_existing_name = existing_name_raw.decode('utf-8') if isinstance(existing_name_raw, bytes) else str(existing_name_raw)
+
+            if current_existing_name == name: # Compare decoded str with input str
+                # Update with input 'name' (already str) and new 'model_uuid' (already str)
                 mappings_list[i] = (name, model_uuid)
                 name_exists = True
                 break


### PR DESCRIPTION
This commit addresses issues in `tensordirectory/storage.py` where updating entries for existing names in the name-to-UUID mappings was failing due to improper string comparisons.

Changes:
- In `save_tensor` and `save_model`:
  - When checking if a name already exists in the index mapping list, the existing name (if read as bytes from HDF5) is now explicitly decoded to a Python string before being compared with the input name (which is a Python string).
  - This ensures that existing entries are correctly identified and their associated UUIDs are updated, rather than new entries being erroneously appended for what should be the same logical name.

This fix is expected to resolve the failures in
`test_04_save_tensor_name_overwrite` and
`test_09_save_model_name_overwrite` in `test_storage.py`.